### PR TITLE
Feature stage3 site indexing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,15 @@
         <jsoup.version>1.18.1</jsoup.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <mockito.version>5.11.0</mockito.version>
+        <lucene.version>1.5</lucene.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>skillbox-gitlab</id>
+            <url>https://gitlab.skillbox.ru/api/v4/projects/263574/packages/maven</url>
+        </repository>
+    </repositories>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -81,6 +89,31 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene.morphology</groupId>
+            <artifactId>morph</artifactId>
+            <version>${lucene.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene.analysis</groupId>
+            <artifactId>morphology</artifactId>
+            <version>${lucene.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene.morphology</groupId>
+            <artifactId>dictionary-reader</artifactId>
+            <version>${lucene.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene.morphology</groupId>
+            <artifactId>english</artifactId>
+            <version>${lucene.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene.morphology</groupId>
+            <artifactId>russian</artifactId>
+            <version>${lucene.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/searchengine/controllers/ApiController.java
+++ b/src/main/java/searchengine/controllers/ApiController.java
@@ -1,9 +1,7 @@
 package searchengine.controllers;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import searchengine.dto.indexing.IndexingResponse;
 import searchengine.dto.statistics.StatisticsResponse;
 import searchengine.services.api.IndexingService;
@@ -29,13 +27,19 @@ public class ApiController {
 
     @GetMapping("/startIndexing")
     public ResponseEntity<IndexingResponse> startIndexing() {
-        IndexingResponse indexingResponse = indexingService.indexingAllSites();
+        IndexingResponse indexingResponse = indexingService.initiateFullIndexing();
         return ResponseEntity.ok(indexingResponse);
     }
 
     @GetMapping("/stopIndexing")
     public ResponseEntity<IndexingResponse> stopIndexing() {
         IndexingResponse response = indexingService.stopIndexing();
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/indexPage")
+    public ResponseEntity<IndexingResponse> startIndexingOnePage(@RequestParam String url) {
+        IndexingResponse response = indexingService.initiatePartialIndexing(url);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/searchengine/dto/indexing/PageIndexingData.java
+++ b/src/main/java/searchengine/dto/indexing/PageIndexingData.java
@@ -1,0 +1,23 @@
+package searchengine.dto.indexing;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import searchengine.model.IndexEntity;
+import searchengine.model.LemmaEntity;
+import searchengine.model.PageEntity;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageIndexingData {
+
+    PageEntity page;
+    List<LemmaEntity> lemmasByPage;
+    List<IndexEntity> indexesByPage;
+
+}

--- a/src/main/java/searchengine/dto/statistics/DetailedStatisticsItem.java
+++ b/src/main/java/searchengine/dto/statistics/DetailedStatisticsItem.java
@@ -1,8 +1,10 @@
 package searchengine.dto.statistics;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class DetailedStatisticsItem {
     private String url;
     private String name;

--- a/src/main/java/searchengine/exceptions/PageAlreadyPresentException.java
+++ b/src/main/java/searchengine/exceptions/PageAlreadyPresentException.java
@@ -1,6 +1,9 @@
 package searchengine.exceptions;
 
 public class PageAlreadyPresentException extends RuntimeException {
+    public PageAlreadyPresentException() {
+    }
+
     public PageAlreadyPresentException(String pageUrl, String siteUrl) {
         super("Page " + pageUrl + " from site " + siteUrl + " is already saved to DB");
     }

--- a/src/main/java/searchengine/model/IndexEntity.java
+++ b/src/main/java/searchengine/model/IndexEntity.java
@@ -1,0 +1,47 @@
+package searchengine.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Objects;
+
+// Lombok
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+// Database
+@Entity
+@Table(name = "search_index")
+public class IndexEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "page_id", nullable = false)
+    private PageEntity page;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lemma_id", nullable = false)
+    private LemmaEntity lemma;
+
+    @Column(name = "lemma_rank", nullable = false)
+    private float rank;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IndexEntity index = (IndexEntity) o;
+        return Float.compare(index.rank, rank) == 0 && Objects.equals(page, index.page) && Objects.equals(lemma, index.lemma);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(page, lemma, rank);
+    }
+
+}

--- a/src/main/java/searchengine/model/LemmaEntity.java
+++ b/src/main/java/searchengine/model/LemmaEntity.java
@@ -1,0 +1,45 @@
+package searchengine.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Objects;
+
+// Lombok
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+// Database
+@Entity
+@Table(name = "lemma", uniqueConstraints = { @UniqueConstraint(columnNames = { "lemma", "site_id" }) })
+public class LemmaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(255) CHARACTER SET utf8mb4")
+    private String lemma;
+
+    @Column(nullable = false)
+    private Integer frequency;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "site_id", referencedColumnName = "id", nullable = false)
+    private SiteEntity site;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LemmaEntity lemma1 = (LemmaEntity) o;
+        return Objects.equals(lemma, lemma1.lemma) && Objects.equals(site, lemma1.site);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lemma, site);
+    }
+}

--- a/src/main/java/searchengine/repository/IndexRepository.java
+++ b/src/main/java/searchengine/repository/IndexRepository.java
@@ -1,0 +1,14 @@
+package searchengine.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import searchengine.model.IndexEntity;
+import searchengine.model.PageEntity;
+
+import java.util.List;
+
+@Repository
+public interface IndexRepository extends JpaRepository<IndexEntity, Integer> {
+
+    List<IndexEntity> findByPage(PageEntity page);
+}

--- a/src/main/java/searchengine/repository/LemmaRepository.java
+++ b/src/main/java/searchengine/repository/LemmaRepository.java
@@ -1,0 +1,14 @@
+package searchengine.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import searchengine.model.LemmaEntity;
+import searchengine.model.SiteEntity;
+
+import java.util.Optional;
+
+@Repository
+public interface LemmaRepository extends JpaRepository<LemmaEntity, Integer> {
+
+    Optional<LemmaEntity> findBySiteAndLemma(SiteEntity site, String lemma);
+}

--- a/src/main/java/searchengine/repository/LemmaRepository.java
+++ b/src/main/java/searchengine/repository/LemmaRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface LemmaRepository extends JpaRepository<LemmaEntity, Integer> {
 
     Optional<LemmaEntity> findBySiteAndLemma(SiteEntity site, String lemma);
+
+    Integer countBySite(SiteEntity siteEntity);
 }

--- a/src/main/java/searchengine/repository/PageRepository.java
+++ b/src/main/java/searchengine/repository/PageRepository.java
@@ -5,15 +5,12 @@ import org.springframework.stereotype.Repository;
 import searchengine.model.PageEntity;
 import searchengine.model.SiteEntity;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PageRepository extends JpaRepository<PageEntity, Integer> {
 
     Optional<PageEntity> findByRelativePathAndSite(String relativePath, SiteEntity site);
-
-    List<PageEntity> findBySite(SiteEntity site);
 
     Integer countBySite(SiteEntity siteEntity);
 

--- a/src/main/java/searchengine/repository/PageRepository.java
+++ b/src/main/java/searchengine/repository/PageRepository.java
@@ -15,4 +15,6 @@ public interface PageRepository extends JpaRepository<PageEntity, Integer> {
 
     List<PageEntity> findBySite(SiteEntity site);
 
+    Integer countBySite(SiteEntity siteEntity);
+
 }

--- a/src/main/java/searchengine/repository/SiteRepository.java
+++ b/src/main/java/searchengine/repository/SiteRepository.java
@@ -4,6 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import searchengine.model.SiteEntity;
 
+import java.util.Optional;
+
 @Repository
 public interface SiteRepository extends JpaRepository<SiteEntity, Integer> {
+
+    Optional<SiteEntity> findByUrl(String url);
+
 }

--- a/src/main/java/searchengine/services/actions/CollectLemmasAction.java
+++ b/src/main/java/searchengine/services/actions/CollectLemmasAction.java
@@ -1,0 +1,77 @@
+package searchengine.services.actions;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.morphology.LuceneMorphology;
+import org.apache.lucene.morphology.russian.RussianLuceneMorphology;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+import org.springframework.stereotype.Service;
+import searchengine.model.PageEntity;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Log4j2
+@Service
+public class CollectLemmasAction {
+
+    private static final String[] PARTICLES_NAMES = new String[]{"МЕЖД", "ПРЕДЛ", "СОЮЗ", "МС"};
+
+    private static LuceneMorphology luceneMorph;
+
+    static {
+        try {
+            luceneMorph = new RussianLuceneMorphology();
+        } catch (IOException e) {
+            log.error(e);
+        }
+    }
+
+    public static String cleanText (PageEntity page) {
+        return Jsoup.clean(page.getContent(), Safelist.simpleText());
+    }
+
+    public static Map<String, Integer> collectLemmasFromTextWithCount(String text) {
+        String[] words = getRussianWordsFromText(text);
+        return Arrays.stream(words)
+                .filter(CollectLemmasAction::isWord)
+                .collect(Collectors.toMap(
+                        word -> getNormalFormOfWord(word),
+                        count -> 1,
+                        Integer::sum));
+    }
+
+    private static String[] getRussianWordsFromText(String text) {
+        return text.toLowerCase(Locale.ROOT)
+                .replaceAll("([^а-я\\s])", " ")
+                .split("\\s+");
+    }
+
+    private static boolean isWord(String word) {
+        if (!word.isEmpty() && word.matches("[а-яё]+")) {
+            return !isAnyWordBaseParticle(word);
+        }
+        return false;
+    }
+
+    private static String getNormalFormOfWord(String word) {
+        return luceneMorph.getNormalForms(word).get(0);
+    }
+
+    private static boolean isAnyWordBaseParticle(String word) {
+        return luceneMorph.getMorphInfo(word).stream().anyMatch(CollectLemmasAction::isParticle);
+    }
+
+    private static boolean isParticle(String form) {
+        for (String particle : PARTICLES_NAMES) {
+            if (form.contains(particle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/searchengine/services/actions/ComputeIndexingInfoAction.java
+++ b/src/main/java/searchengine/services/actions/ComputeIndexingInfoAction.java
@@ -14,9 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static searchengine.services.actions.CollectLemmasAction.cleanText;
-import static searchengine.services.actions.CollectLemmasAction.collectLemmasFromTextWithCount;
-
 @Log4j2
 public class ComputeIndexingInfoAction {
 
@@ -26,8 +23,9 @@ public class ComputeIndexingInfoAction {
         log.info("Computing indexing info for page {} started",
                 page.getSite().getUrl() + page.getRelativePath());
         Instant start = Instant.now();
-        String cleanedPageContent = cleanText(page);
-        Map<String, Integer> lemmasFromTextWithCount = collectLemmasFromTextWithCount(cleanedPageContent);
+        String cleanedPageContent = CollectLemmasAction.cleanText(page.getContent());
+        Map<String, Integer> lemmasFromTextWithCount =
+                CollectLemmasAction.collectLemmasFromCleanedTextWithCount(cleanedPageContent);
         PageIndexingData pageIndexingData = computePageIndexingData(
                 lemmaService, indexService, lemmasFromTextWithCount, page);
         Instant end = Instant.now();

--- a/src/main/java/searchengine/services/actions/ComputeIndexingInfoAction.java
+++ b/src/main/java/searchengine/services/actions/ComputeIndexingInfoAction.java
@@ -1,0 +1,58 @@
+package searchengine.services.actions;
+
+import lombok.extern.log4j.Log4j2;
+import searchengine.dto.indexing.PageIndexingData;
+import searchengine.model.IndexEntity;
+import searchengine.model.LemmaEntity;
+import searchengine.model.PageEntity;
+import searchengine.services.entity.IndexService;
+import searchengine.services.entity.LemmaService;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static searchengine.services.actions.CollectLemmasAction.cleanText;
+import static searchengine.services.actions.CollectLemmasAction.collectLemmasFromTextWithCount;
+
+@Log4j2
+public class ComputeIndexingInfoAction {
+
+    public static PageIndexingData computeIndexingInfoForPage(LemmaService lemmaService,
+                                                              IndexService indexService,
+                                                              PageEntity page) {
+        log.info("Computing indexing info for page {} started",
+                page.getSite().getUrl() + page.getRelativePath());
+        Instant start = Instant.now();
+        String cleanedPageContent = cleanText(page);
+        Map<String, Integer> lemmasFromTextWithCount = collectLemmasFromTextWithCount(cleanedPageContent);
+        PageIndexingData pageIndexingData = computePageIndexingData(
+                lemmaService, indexService, lemmasFromTextWithCount, page);
+        Instant end = Instant.now();
+        Duration duration = Duration.between(start, end);
+        log.info("Computing indexing info for page {} completed in {} min {} sec {} ms",
+                page.getSite().getUrl() + page.getRelativePath(),
+                duration.toMinutes(), duration.toSecondsPart(), duration.toMillisPart());
+        return pageIndexingData;
+    }
+
+    private static PageIndexingData computePageIndexingData(LemmaService lemmaService,
+                                                            IndexService indexService,
+                                                            Map<String, Integer> lemmasFromTextWithCount,
+                                                            PageEntity page) {
+        List<LemmaEntity> lemmasByPage = new ArrayList<>();
+        List<IndexEntity> indexesByPage = new ArrayList<>();
+        PageIndexingData pageIndexingData = new PageIndexingData(page, lemmasByPage, indexesByPage);
+        for (String lemma : lemmasFromTextWithCount.keySet()) {
+            LemmaEntity lemmaEntity = lemmaService.correctLemmaFrequencyBySite(lemma, page.getSite());
+            Float rank = Float.valueOf(lemmasFromTextWithCount.get(lemma));
+            IndexEntity indexEntity = indexService.createIndexForPage(lemmaEntity, rank, page);
+            lemmasByPage.add(lemmaEntity);
+            indexesByPage.add(indexEntity);
+        }
+        return pageIndexingData;
+    }
+
+}

--- a/src/main/java/searchengine/services/actions/ExtractConnectionInfoAction.java
+++ b/src/main/java/searchengine/services/actions/ExtractConnectionInfoAction.java
@@ -14,14 +14,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static searchengine.services.actions.FormatUrlAction.isGoodLink;
-
 @Log4j2
 public class ExtractConnectionInfoAction {
 
     private static final String CSS_QUERY = "a[href]";
     private static final String LINK_ELEMENT_KEY = "href";
-    private static final Integer PAGE_CODE_SUCCESS = 200;
+    public static final Integer PAGE_CODE_SUCCESS = 200;
 
     private static final List<String> ACCEPTABLE_CONTENT_TYPES = List.of(
             "text/plain",
@@ -72,7 +70,7 @@ public class ExtractConnectionInfoAction {
             Elements links = doc.select(CSS_QUERY);
             return links.stream()
                     .map(linkCode -> linkCode.absUrl(LINK_ELEMENT_KEY))
-                    .filter(link -> isGoodLink(pageUrl, link))
+                    .filter(link -> FormatUrlAction.isGoodLink(pageUrl, link))
                     .collect(Collectors.toSet());
         }
         return Collections.emptySet();

--- a/src/main/java/searchengine/services/actions/FormatUrlAction.java
+++ b/src/main/java/searchengine/services/actions/FormatUrlAction.java
@@ -42,4 +42,8 @@ public class FormatUrlAction {
     public static boolean isHomePageRelativePath(String relativePath) {
         return StringUtils.equals(relativePath, SITE_HOME_PAGE_RELATIVE_PATH);
     }
+
+    public static boolean isPagePartOfSite(String siteUrl, String pageUrl) {
+        return StringUtils.containsIgnoreCase(pageUrl, siteUrl);
+    }
 }

--- a/src/main/java/searchengine/services/actions/FormatUrlAction.java
+++ b/src/main/java/searchengine/services/actions/FormatUrlAction.java
@@ -4,11 +4,14 @@ import org.apache.commons.lang3.StringUtils;
 import searchengine.exceptions.PageNotFromSiteException;
 import searchengine.model.SiteEntity;
 
+import java.util.List;
+
 public class FormatUrlAction {
 
     private static final String SCROLLUP_LINK = "#";
     private static final String ESCAPE_SYMBOL = "/";
     public static final String SITE_HOME_PAGE_RELATIVE_PATH = ESCAPE_SYMBOL;
+    private static final List<String> URL_IS_FILE = List.of(".doc", ".docx", ".pdf", ".png", ".jpg", ".jpeg");
 
     public static String convertAbsPathToRelativePath(String absPath, SiteEntity site) {
         String siteUrl = removeEscapeEnd(site.getUrl());
@@ -31,12 +34,17 @@ public class FormatUrlAction {
         link = removeEscapeEnd(link);
         return StringUtils.startsWithIgnoreCase(link, pageUrl) &&
                 !isSameLink(pageUrl, link) &&
-                !StringUtils.endsWith(link, SCROLLUP_LINK) &&
-                !StringUtils.startsWithIgnoreCase(link, pageUrl + SCROLLUP_LINK);
+                !StringUtils.contains(link, SCROLLUP_LINK) &&
+                !StringUtils.startsWithIgnoreCase(link, pageUrl + SCROLLUP_LINK) &&
+                !isFileLink(link);
     }
 
     private static boolean isSameLink(String link1, String link2) {
         return StringUtils.equalsIgnoreCase(link1, link2);
+    }
+
+    private static boolean isFileLink(String link) {
+        return URL_IS_FILE.stream().anyMatch(fileLinkPart -> StringUtils.containsIgnoreCase(link, fileLinkPart));
     }
 
     public static boolean isHomePageRelativePath(String relativePath) {

--- a/src/main/java/searchengine/services/actions/GenerateIndexingResponseAction.java
+++ b/src/main/java/searchengine/services/actions/GenerateIndexingResponseAction.java
@@ -11,10 +11,12 @@ public class GenerateIndexingResponseAction {
     public static final String INDEXING_ALREADY_STARTED_ERROR = "Индексация уже запущена";
     public static final String INDEXING_NOT_STARTED_ERROR = "Индексация не запущена";
     public static final String SITE_HOME_PAGE_NOT_ACCESSIBLE = "Главная страница сайта недоступна";
+    public static final String PAGE_NOT_LISTED_IN_CONFIG = "Данная страница находится за пределами сайтов, указанных в конфигурационном файле";
 
     private static final IndexingResponse INDEXING_ALREADY_STARTED_RESPONSE = new IndexingResponse(false, INDEXING_ALREADY_STARTED_ERROR);
     private static final IndexingResponse INDEXING_NOT_STARTED_RESPONSE = new IndexingResponse(false, INDEXING_NOT_STARTED_ERROR);
     private static final IndexingResponse SITE_HOME_PAGE_NOT_ACCESSIBLE_RESPONSE = new IndexingResponse(false, SITE_HOME_PAGE_NOT_ACCESSIBLE);
+    private static final IndexingResponse PAGE_NOT_LISTED_IN_CONFIG_RESPONSE = new IndexingResponse(false, PAGE_NOT_LISTED_IN_CONFIG);
     private static final IndexingResponse GOOD_INDEXING_RESPONSE = new IndexingResponse(true, "");
 
     public static IndexingResponse getIndexingAlreadyStartedResponse() {
@@ -35,6 +37,11 @@ public class GenerateIndexingResponseAction {
     public static IndexingResponse getSiteHomePageNotAccessibleResponse(String siteUrl) {
         log.error("Home page for site {} is not accessible", siteUrl);
         return SITE_HOME_PAGE_NOT_ACCESSIBLE_RESPONSE;
+    }
+
+    public static IndexingResponse getPageNotListedInConfigResponse(String pageUrl) {
+        log.error("Page with url {} is not part of site list in configuration file", pageUrl);
+        return PAGE_NOT_LISTED_IN_CONFIG_RESPONSE;
     }
 
     public static IndexingResponse getAllGoodResponse() {

--- a/src/main/java/searchengine/services/actions/HandleExceptionsAction.java
+++ b/src/main/java/searchengine/services/actions/HandleExceptionsAction.java
@@ -1,13 +1,11 @@
 package searchengine.services.actions;
 
 import lombok.extern.log4j.Log4j2;
+import searchengine.exceptions.InvalidSearchQueryException;
 import searchengine.exceptions.PageAlreadyPresentException;
 import searchengine.model.SiteEntity;
+import searchengine.model.SiteIndexingStatus;
 import searchengine.services.entity.SiteService;
-
-import static searchengine.model.SiteIndexingStatus.FAILED;
-import static searchengine.services.actions.GenerateLockAction.lockSiteParseWriteLock;
-import static searchengine.services.actions.GenerateLockAction.unlockSiteParseWriteLock;
 
 @Log4j2
 public class HandleExceptionsAction {
@@ -19,9 +17,9 @@ public class HandleExceptionsAction {
 
     public static void handleUnexpectedIndexingException(SiteService siteService, SiteEntity site, Exception ex) {
         try {
-            lockSiteParseWriteLock();
+            GenerateLockAction.lockSiteParseWriteLock();
             siteService.updateSiteStatusInfo(
-                    FAILED,
+                    SiteIndexingStatus.FAILED,
                     "Unexpected exception : " + ex.getMessage() + ". See logs for more information.",
                     site);
             siteService.save(site);
@@ -29,7 +27,7 @@ public class HandleExceptionsAction {
         } catch (Exception exception) {
             log.error("Exception inside of exception while saving info for site {}", site.getUrl(), ex);
         } finally {
-            unlockSiteParseWriteLock();
+            GenerateLockAction.unlockSiteParseWriteLock();
         }
     }
 }

--- a/src/main/java/searchengine/services/actions/HandleExceptionsAction.java
+++ b/src/main/java/searchengine/services/actions/HandleExceptionsAction.java
@@ -1,0 +1,35 @@
+package searchengine.services.actions;
+
+import lombok.extern.log4j.Log4j2;
+import searchengine.exceptions.PageAlreadyPresentException;
+import searchengine.model.SiteEntity;
+import searchengine.services.entity.SiteService;
+
+import static searchengine.model.SiteIndexingStatus.FAILED;
+import static searchengine.services.actions.GenerateLockAction.lockSiteParseWriteLock;
+import static searchengine.services.actions.GenerateLockAction.unlockSiteParseWriteLock;
+
+@Log4j2
+public class HandleExceptionsAction {
+
+    public static void handlePageAlreadyPresentExceptions(String pageUrl, SiteEntity site) {
+        PageAlreadyPresentException exception = new PageAlreadyPresentException(pageUrl, site.getUrl());
+        log.warn(exception.getMessage());
+    }
+
+    public static void handleUnexpectedIndexingException(SiteService siteService, SiteEntity site, Exception ex) {
+        try {
+            lockSiteParseWriteLock();
+            siteService.updateSiteStatusInfo(
+                    FAILED,
+                    "Unexpected exception : " + ex.getMessage() + ". See logs for more information.",
+                    site);
+            siteService.save(site);
+            log.error("Site {} was saved as FAILED because of unexpected exception", site.getUrl(), ex);
+        } catch (Exception exception) {
+            log.error("Exception inside of exception while saving info for site {}", site.getUrl(), ex);
+        } finally {
+            unlockSiteParseWriteLock();
+        }
+    }
+}

--- a/src/main/java/searchengine/services/actions/IndexingThreadAction.java
+++ b/src/main/java/searchengine/services/actions/IndexingThreadAction.java
@@ -1,0 +1,142 @@
+package searchengine.services.actions;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import searchengine.config.JsoupConfig;
+import searchengine.config.Site;
+import searchengine.dto.indexing.IndexingResponse;
+import searchengine.exceptions.IndexingStoppedByUserException;
+import searchengine.model.PageEntity;
+import searchengine.model.SiteEntity;
+import searchengine.model.SiteIndexingStatus;
+import searchengine.services.entity.IndexService;
+import searchengine.services.entity.LemmaService;
+import searchengine.services.entity.PageService;
+import searchengine.services.entity.SiteService;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinPool;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class IndexingThreadAction {
+
+    @Setter
+    public static volatile boolean isCancelledStopIndexing = false;
+
+    private final JsoupConfig jsoupConfig;
+    private final SiteService siteService;
+    private final PageService pageService;
+    private final LemmaService lemmaService;
+    private final IndexService indexService;
+
+    public IndexingResponse indexingOneSite(String url,
+                                            String name,
+                                            CountDownLatch countDownLatch) {
+        log.info("Indexing site {} started", url);
+        Instant start = Instant.now();
+        SiteEntity site = siteService.createSiteByNameAndUrl(name, url);
+        siteService.save(site);
+        if (isCancelledStopIndexing) {
+            handleStopByUser(site);
+            return GenerateIndexingResponseAction.getIndexingStoppedByUserResponse();
+        }
+        IndexingResponse indexingOneSiteResponse = gatherSiteIndexingInfo(site);
+        Instant end = Instant.now();
+        Duration duration = Duration.between(start, end);
+        log.info("Indexing site {} complete in {} minutes {} seconds",
+                site.getUrl(), duration.toMinutes(), duration.toSecondsPart());
+        countDownLatch.countDown();
+        return indexingOneSiteResponse;
+    }
+
+    private void handleStopByUser(SiteEntity site) {
+        try {
+            GenerateLockAction.lockSiteParseWriteLock();
+            siteService.updateSiteStatusInfo(
+                    SiteIndexingStatus.FAILED,
+                    GenerateIndexingResponseAction.INDEXING_STOPPED_BY_USER_ERROR,
+                    site);
+            siteService.save(site);
+            log.info("Site {} was saved as FAILED because of user stop", site.getUrl());
+        } catch (Exception ex) {
+            log.error("Exception while saving INDEXING STOPPED BY USER info for site {}", site.getUrl(), ex);
+        } finally {
+            GenerateLockAction.unlockSiteParseWriteLock();
+        }
+    }
+
+    @Transactional
+    public IndexingResponse gatherSiteIndexingInfo(SiteEntity site) {
+        IndexingResponse indexingResponse = null;
+        try {
+            parseSite(site);
+            indexingResponse = getResponseAccordingToSiteStatus(site);
+        } catch (IndexingStoppedByUserException ex) {
+            handleStopByUser(site);
+            indexingResponse = GenerateIndexingResponseAction.getIndexingStoppedByUserResponse();
+        } catch (Exception ex) {
+            HandleExceptionsAction.handleUnexpectedIndexingException(siteService, site, ex);
+        } finally {
+            log.info("Indexing for site {} is completed with status {}", site.getUrl(), site.getStatus());
+        }
+        return indexingResponse;
+    }
+
+    private void parseSite(SiteEntity site) {
+        ForkJoinPool forkJoinPool = new ForkJoinPool();
+        ParseAction parser = new ParseAction(site.getUrl(), site, jsoupConfig, siteService, pageService, lemmaService, indexService);
+        forkJoinPool.invoke(parser);
+        if (isCancelledStopIndexing) {
+            forkJoinPool.shutdownNow();
+            throw new IndexingStoppedByUserException();
+        }
+    }
+
+    private IndexingResponse getResponseAccordingToSiteStatus(SiteEntity site) {
+        if (site.getStatus() == SiteIndexingStatus.FAILED) {
+            return GenerateIndexingResponseAction.getIndexingFailedErrorResponse(site.getUrl(), site.getLastError());
+        }
+        if (!pageService.isSiteHomePageAccessible(site)) {
+            siteService.updateSiteStatusInfo(
+                    SiteIndexingStatus.FAILED,
+                    GenerateIndexingResponseAction.SITE_HOME_PAGE_NOT_ACCESSIBLE,
+                    site);
+            siteService.save(site);
+            return GenerateIndexingResponseAction.getSiteHomePageNotAccessibleResponse(site.getUrl());
+        }
+        siteService.updateSiteStatusInfo(SiteIndexingStatus.INDEXED, "", site);
+        siteService.save(site);
+        return GenerateIndexingResponseAction.getAllGoodResponse();
+    }
+
+    @Transactional
+    public void indexingAddedPage(String url, Site siteInConfig) {
+        log.info("Indexing page is started, url - {}", url);
+        SiteEntity site = siteService.getByUrl(siteInConfig.getUrl());
+        if (site == null) {
+            site = siteService.createSiteByNameAndUrl(siteInConfig.getName(), siteInConfig.getUrl());
+            siteService.save(site);
+        }
+        PageEntity page = pageService.getByAbsPathAndSite(url, site);
+        if (page != null) {
+            PrepareDatabaseBeforeIndexingAction.prepareDatabaseBeforePartialIndexingStart(
+                    pageService, lemmaService, indexService, page);
+        }
+        parseAddedPage(url, site);
+        getResponseAccordingToSiteStatus(site);
+        log.info("Indexing page is finished, url - {}", url);
+    }
+
+    private void parseAddedPage(String url, SiteEntity site) {
+        ParseAction parser = new ParseAction(url, site, jsoupConfig, siteService, pageService, lemmaService, indexService);
+        parser.invoke();
+    }
+
+}

--- a/src/main/java/searchengine/services/actions/PrepareDatabaseBeforeIndexingAction.java
+++ b/src/main/java/searchengine/services/actions/PrepareDatabaseBeforeIndexingAction.java
@@ -1,0 +1,56 @@
+package searchengine.services.actions;
+
+import lombok.extern.log4j.Log4j2;
+import searchengine.model.IndexEntity;
+import searchengine.model.LemmaEntity;
+import searchengine.model.PageEntity;
+import searchengine.services.entity.IndexService;
+import searchengine.services.entity.LemmaService;
+import searchengine.services.entity.PageService;
+import searchengine.services.entity.SiteService;
+
+import java.util.List;
+
+@Log4j2
+public class PrepareDatabaseBeforeIndexingAction {
+
+    public static void prepareDatabaseBeforeFullIndexingStart(SiteService siteService,
+                                                              PageService pageService,
+                                                              LemmaService lemmaService,
+                                                              IndexService indexService) {
+        log.info("Deleting all info from database started");
+        indexService.deleteAll();
+        lemmaService.deleteAll();
+        pageService.deleteAll();
+        siteService.deleteAll();
+        log.info("Deleting all info from database completed");
+    }
+
+    public static void prepareDatabaseBeforePartialIndexingStart(PageService pageService,
+                                                                 LemmaService lemmaService,
+                                                                 IndexService indexService,
+                                                                 PageEntity page) {
+        log.info("Deleting info related to {} from database started",
+                page.getSite().getUrl() + page.getRelativePath());
+        deleteIndexingInfoByPage(page, lemmaService, indexService);
+        pageService.delete(page);
+        log.info("Deleting info related to {} from database completed",
+                page.getSite().getUrl() + page.getRelativePath());
+    }
+
+    private static void deleteIndexingInfoByPage(PageEntity page,
+                                                 LemmaService lemmaService,
+                                                 IndexService indexService) {
+        List<IndexEntity> indexesByPage = indexService.getByPage(page);
+        if (indexesByPage == null || indexesByPage.isEmpty()) {
+            log.error("Index list by page {} is empty", page.getSite().getUrl() + page.getRelativePath());
+            return;
+        }
+        List<LemmaEntity> lemmasByPage = indexesByPage.stream().map(IndexEntity::getLemma).toList();
+        log.info("Page {} - indexes count : {}, lemmas count {}",
+                page.getSite().getUrl() + page.getRelativePath(), indexesByPage.size(), lemmasByPage.size());
+        indexService.deleteAll(indexesByPage);
+        lemmasByPage.forEach(lemmaService::decreaseLemmaFrequencyInDatabase);
+    }
+
+}

--- a/src/main/java/searchengine/services/api/IndexingService.java
+++ b/src/main/java/searchengine/services/api/IndexingService.java
@@ -3,9 +3,9 @@ package searchengine.services.api;
 import searchengine.dto.indexing.IndexingResponse;
 
 public interface IndexingService {
-    IndexingResponse indexingAllSites();
+    IndexingResponse initiateFullIndexing();
 
-    IndexingResponse indexingAddedPage();
+    IndexingResponse initiatePartialIndexing(String url);
 
     IndexingResponse stopIndexing();
 }

--- a/src/main/java/searchengine/services/api/impl/IndexingServiceImpl.java
+++ b/src/main/java/searchengine/services/api/impl/IndexingServiceImpl.java
@@ -12,9 +12,12 @@ import searchengine.config.Site;
 import searchengine.config.SitesList;
 import searchengine.dto.indexing.IndexingResponse;
 import searchengine.exceptions.IndexingStoppedByUserException;
+import searchengine.model.PageEntity;
 import searchengine.model.SiteEntity;
 import searchengine.services.actions.ParseAction;
 import searchengine.services.api.IndexingService;
+import searchengine.services.entity.IndexService;
+import searchengine.services.entity.LemmaService;
 import searchengine.services.entity.PageService;
 import searchengine.services.entity.SiteService;
 
@@ -29,8 +32,12 @@ import java.util.concurrent.ForkJoinPool;
 
 import static searchengine.model.SiteIndexingStatus.FAILED;
 import static searchengine.model.SiteIndexingStatus.INDEXED;
+import static searchengine.services.actions.FormatUrlAction.isPagePartOfSite;
 import static searchengine.services.actions.GenerateIndexingResponseAction.*;
 import static searchengine.services.actions.GenerateLockAction.*;
+import static searchengine.services.actions.HandleExceptionsAction.handleUnexpectedIndexingException;
+import static searchengine.services.actions.PrepareDatabaseBeforeIndexingAction.prepareDatabaseBeforeFullIndexingStart;
+import static searchengine.services.actions.PrepareDatabaseBeforeIndexingAction.prepareDatabaseBeforePartialIndexingStart;
 
 @Log4j2
 @Service
@@ -50,26 +57,21 @@ public class IndexingServiceImpl implements IndexingService {
     private final JsoupConfig jsoupConfig;
     private final SiteService siteService;
     private final PageService pageService;
+    private final LemmaService lemmaService;
+    private final IndexService indexService;
 
     @Override
-    public IndexingResponse indexingAllSites() {
-        if (isIndexingInProcess()) {
+    public IndexingResponse initiateFullIndexing() {
+        if (isIndexingInProcess) {
             return getIndexingAlreadyStartedResponse();
         }
         log.info("Full indexing initiated by user");
-        setCancelledStopIndexing(false);
-        setIndexingInProcess(true);
-        prepareDatabaseBeforeIndexingStart();
-        Thread indexingTask = new Thread(this::indexSiteListFromConfig, "indexing-thread");
+        setIndexingFlags(false, true);
+        prepareDatabaseBeforeFullIndexingStart(siteService, pageService, lemmaService, indexService);
+        ParseAction.readyForFullParsing();
+        Thread indexingTask = new Thread(this::indexSiteListFromConfig, "site-indexing-thread");
         indexingTask.start();
         return getAllGoodResponse();
-    }
-
-    private void prepareDatabaseBeforeIndexingStart() {
-        log.info("Deleting all info from database started");
-        pageService.deleteAll();
-        siteService.deleteAll();
-        log.info("Deleting all info from database completed");
     }
 
     private void indexSiteListFromConfig() {
@@ -89,7 +91,8 @@ public class IndexingServiceImpl implements IndexingService {
         executorThreadPool = Executors.newFixedThreadPool(siteList.size());
         try {
             for (Site site : siteList) {
-                executorThreadPool.submit(() -> indexingOneSite(site.getUrl(), site.getName(), countDownLatch));
+                executorThreadPool.submit(() ->
+                        indexingOneSite(site.getUrl(), site.getName(), countDownLatch));
             }
             countDownLatch.await();
         } catch (InterruptedException ex) {
@@ -130,7 +133,7 @@ public class IndexingServiceImpl implements IndexingService {
             siteService.save(site);
             log.info("Site {} was saved as FAILED because of user stop", site.getUrl());
         } catch (Exception ex) {
-            log.error("Exception while saving INDEXING STOPPED BY USER info for sile {}", site.getUrl(), ex);
+            log.error("Exception while saving INDEXING STOPPED BY USER info for site {}", site.getUrl(), ex);
         } finally {
             unlockSiteParseWriteLock();
         }
@@ -145,7 +148,7 @@ public class IndexingServiceImpl implements IndexingService {
             handleStopByUser(site);
             indexingResponse = getIndexingStoppedByUserResponse();
         } catch (Exception ex) {
-            log.error("Unexpected exception while processing site {}", site.getUrl(), ex);
+            handleUnexpectedIndexingException(siteService, site, ex);
         } finally {
             log.info("Indexing for site {} is completed with status {}", site.getUrl(), site.getStatus());
         }
@@ -168,7 +171,7 @@ public class IndexingServiceImpl implements IndexingService {
 
     private void parseSite(SiteEntity site) {
         ForkJoinPool forkJoinPool = new ForkJoinPool();
-        ParseAction parser = new ParseAction(site.getUrl(), site, jsoupConfig, siteService, pageService);
+        ParseAction parser = new ParseAction(site.getUrl(), site, jsoupConfig, siteService, pageService, lemmaService, indexService);
         forkJoinPool.invoke(parser);
         if (isCancelledStopIndexing()) {
             forkJoinPool.shutdownNow();
@@ -185,26 +188,67 @@ public class IndexingServiceImpl implements IndexingService {
             siteService.save(site);
             return getSiteHomePageNotAccessibleResponse(site.getUrl());
         }
-        // тут будет всякое леммасобирательство
         siteService.updateSiteStatusInfo(INDEXED, "", site);
         siteService.save(site);
         return getAllGoodResponse();
     }
 
-    @Override
-    public IndexingResponse indexingAddedPage() {
-        return new IndexingResponse(false, "test indexingAddedPage response");
+    private Site getSiteForRequestedPageInConfig(String url) {
+        List<Site> siteList = sites.getSites();
+        return siteList.stream()
+                .filter(site -> isPagePartOfSite(site.getUrl(), url))
+                .findAny()
+                .orElse(null);
     }
 
     @Override
     public IndexingResponse stopIndexing() {
-        if (!isIndexingInProcess()) {
+        if (!isIndexingInProcess) {
             return getIndexingNotStartedResponse();
         }
         executorThreadPool.shutdownNow();
-        setCancelledStopIndexing(true);
-        setIndexingInProcess(false);
+        setIndexingFlags(true, false);
         ParseAction.stopParsing();
         return getIndexingStoppedByUserResponse();
     }
+
+    @Override
+    public IndexingResponse initiatePartialIndexing(String url) {
+        log.info("Indexing page initiated by user, url - {}", url);
+        Site siteInConfig = getSiteForRequestedPageInConfig(url);
+        if (siteInConfig == null) {
+            return getPageNotListedInConfigResponse(url);
+        }
+        indexingAddedPage(url, siteInConfig);
+        return getAllGoodResponse();
+    }
+
+    @Transactional
+    public void indexingAddedPage(String url, Site siteInConfig) {
+        log.info("Indexing page is started, url - {}", url);
+        SiteEntity site = siteService.getByUrl(siteInConfig.getUrl());
+        if (site == null) {
+            site = siteService.createSiteByNameAndUrl(siteInConfig.getName(), siteInConfig.getUrl());
+            siteService.save(site);
+        }
+        PageEntity page = pageService.getByAbsPathAndSite(url, site);
+        if (page != null) {
+            prepareDatabaseBeforePartialIndexingStart(pageService, lemmaService, indexService, page);
+        }
+        parseAddedPage(url, site);
+        getResponseAccordingToSiteStatus(site);
+        log.info("Indexing page is finished, url - {}", url);
+    }
+
+    private void parseAddedPage(String url, SiteEntity site) {
+        ParseAction parser = new ParseAction(url, site, jsoupConfig, siteService, pageService, lemmaService, indexService);
+        ParseAction.readyForLimitedParsing();
+        parser.invoke();
+    }
+
+    private void setIndexingFlags(boolean isCancelledStopIndexing, boolean isIndexingInProcess) {
+        setCancelledStopIndexing(isCancelledStopIndexing);
+        setIndexingInProcess(isIndexingInProcess);
+    }
+
 }

--- a/src/main/java/searchengine/services/api/impl/IndexingServiceImpl.java
+++ b/src/main/java/searchengine/services/api/impl/IndexingServiceImpl.java
@@ -6,38 +6,22 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import searchengine.config.JsoupConfig;
 import searchengine.config.Site;
 import searchengine.config.SitesList;
 import searchengine.dto.indexing.IndexingResponse;
-import searchengine.exceptions.IndexingStoppedByUserException;
-import searchengine.model.PageEntity;
-import searchengine.model.SiteEntity;
-import searchengine.services.actions.ParseAction;
+import searchengine.model.SiteIndexingStatus;
+import searchengine.services.actions.*;
 import searchengine.services.api.IndexingService;
 import searchengine.services.entity.IndexService;
 import searchengine.services.entity.LemmaService;
 import searchengine.services.entity.PageService;
 import searchengine.services.entity.SiteService;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ForkJoinPool;
-
-import static searchengine.model.SiteIndexingStatus.FAILED;
-import static searchengine.model.SiteIndexingStatus.INDEXED;
-import static searchengine.services.actions.FormatUrlAction.isPagePartOfSite;
-import static searchengine.services.actions.GenerateIndexingResponseAction.*;
-import static searchengine.services.actions.GenerateLockAction.*;
-import static searchengine.services.actions.HandleExceptionsAction.handleUnexpectedIndexingException;
-import static searchengine.services.actions.PrepareDatabaseBeforeIndexingAction.prepareDatabaseBeforeFullIndexingStart;
-import static searchengine.services.actions.PrepareDatabaseBeforeIndexingAction.prepareDatabaseBeforePartialIndexingStart;
 
 @Log4j2
 @Service
@@ -46,32 +30,30 @@ public class IndexingServiceImpl implements IndexingService {
 
     @Setter(AccessLevel.PRIVATE)
     @Getter
-    private static volatile boolean isCancelledStopIndexing = false;
-    @Setter(AccessLevel.PRIVATE)
-    @Getter
     private static volatile boolean isIndexingInProcess = false;
 
     private ExecutorService executorThreadPool;
 
     private final SitesList sites;
-    private final JsoupConfig jsoupConfig;
     private final SiteService siteService;
     private final PageService pageService;
     private final LemmaService lemmaService;
     private final IndexService indexService;
+    private final IndexingThreadAction indexingThreadAction;
 
     @Override
     public IndexingResponse initiateFullIndexing() {
         if (isIndexingInProcess) {
-            return getIndexingAlreadyStartedResponse();
+            return GenerateIndexingResponseAction.getIndexingAlreadyStartedResponse();
         }
         log.info("Full indexing initiated by user");
-        setIndexingFlags(false, true);
-        prepareDatabaseBeforeFullIndexingStart(siteService, pageService, lemmaService, indexService);
-        ParseAction.readyForFullParsing();
+        setIndexingInProcessStatus();
+        PrepareDatabaseBeforeIndexingAction.prepareDatabaseBeforeFullIndexingStart(
+                siteService, pageService, lemmaService, indexService);
+        ParseAction.isReadyForFullParsing();
         Thread indexingTask = new Thread(this::indexSiteListFromConfig, "site-indexing-thread");
         indexingTask.start();
-        return getAllGoodResponse();
+        return GenerateIndexingResponseAction.getAllGoodResponse();
     }
 
     private void indexSiteListFromConfig() {
@@ -81,7 +63,7 @@ public class IndexingServiceImpl implements IndexingService {
         if (!isIndexingFinishedCorrectly()) {
             log.error("Some site statuses are incorrect after completing full indexing");
         }
-        setIndexingInProcess(false);
+        setIndexingCompletedStatus();
         log.info("Indexing complete flag was returned to original state");
         log.info("Full indexing is finished");
     }
@@ -92,7 +74,7 @@ public class IndexingServiceImpl implements IndexingService {
         try {
             for (Site site : siteList) {
                 executorThreadPool.submit(() ->
-                        indexingOneSite(site.getUrl(), site.getName(), countDownLatch));
+                        indexingThreadAction.indexingOneSite(site.getUrl(), site.getName(), countDownLatch));
             }
             countDownLatch.await();
         } catch (InterruptedException ex) {
@@ -102,101 +84,25 @@ public class IndexingServiceImpl implements IndexingService {
         }
     }
 
-    @Transactional
-    public IndexingResponse indexingOneSite(String url, String name, CountDownLatch countDownLatch) {
-        log.info("Indexing site {} started", url);
-        Instant start = Instant.now();
-        SiteEntity site = siteService.createSiteByNameAndUrl(name, url);
-        siteService.save(site);
-        if (isCancelledStopIndexing()) {
-            handleStopByUser(site);
-            return getIndexingStoppedByUserResponse();
-        }
-        IndexingResponse indexingOneSiteResponse = gatherSiteIndexingInfo(site);
-        Instant end = Instant.now();
-        Duration duration = Duration.between(start, end);
-        log.info("Indexing site {} complete in {} minutes {} seconds",
-                site.getUrl(),
-                duration.toMinutes(),
-                duration.toSecondsPart());
-        countDownLatch.countDown();
-        return indexingOneSiteResponse;
-    }
-
-    private void handleStopByUser(SiteEntity site) {
-        try {
-            lockSiteParseWriteLock();
-            siteService.updateSiteStatusInfo(
-                    FAILED,
-                    INDEXING_STOPPED_BY_USER_ERROR,
-                    site);
-            siteService.save(site);
-            log.info("Site {} was saved as FAILED because of user stop", site.getUrl());
-        } catch (Exception ex) {
-            log.error("Exception while saving INDEXING STOPPED BY USER info for site {}", site.getUrl(), ex);
-        } finally {
-            unlockSiteParseWriteLock();
-        }
-    }
-
-    private IndexingResponse gatherSiteIndexingInfo(SiteEntity site) {
-        IndexingResponse indexingResponse = null;
-        try {
-            parseSite(site);
-            indexingResponse = getResponseAccordingToSiteStatus(site);
-        } catch (IndexingStoppedByUserException ex) {
-            handleStopByUser(site);
-            indexingResponse = getIndexingStoppedByUserResponse();
-        } catch (Exception ex) {
-            handleUnexpectedIndexingException(siteService, site, ex);
-        } finally {
-            log.info("Indexing for site {} is completed with status {}", site.getUrl(), site.getStatus());
-        }
-        return indexingResponse;
-    }
-
     private boolean isIndexingFinishedCorrectly() {
         boolean isIndexingFinished = false;
         try {
-            lockSiteParseReadLock();
+            GenerateLockAction.lockSiteParseReadLock();
             isIndexingFinished = siteService.getAll().stream()
-                    .allMatch(site -> Objects.equals(site.getStatus(), INDEXED) || Objects.equals(site.getStatus(), FAILED));
+                    .allMatch(site -> Objects.equals(site.getStatus(), SiteIndexingStatus.INDEXED) ||
+                            Objects.equals(site.getStatus(), SiteIndexingStatus.FAILED));
         } catch (Exception ex) {
             log.error("Exception while checking all sites statuses", ex);
         } finally {
-            unlockSiteParseReadLock();
+            GenerateLockAction.unlockSiteParseReadLock();
         }
         return isIndexingFinished;
-    }
-
-    private void parseSite(SiteEntity site) {
-        ForkJoinPool forkJoinPool = new ForkJoinPool();
-        ParseAction parser = new ParseAction(site.getUrl(), site, jsoupConfig, siteService, pageService, lemmaService, indexService);
-        forkJoinPool.invoke(parser);
-        if (isCancelledStopIndexing()) {
-            forkJoinPool.shutdownNow();
-            throw new IndexingStoppedByUserException();
-        }
-    }
-
-    private IndexingResponse getResponseAccordingToSiteStatus(SiteEntity site) {
-        if (site.getStatus() == FAILED) {
-            return getIndexingFailedErrorResponse(site.getUrl(), site.getLastError());
-        }
-        if (!pageService.isSiteHomePageAccessible(site)) {
-            siteService.updateSiteStatusInfo(FAILED, SITE_HOME_PAGE_NOT_ACCESSIBLE, site);
-            siteService.save(site);
-            return getSiteHomePageNotAccessibleResponse(site.getUrl());
-        }
-        siteService.updateSiteStatusInfo(INDEXED, "", site);
-        siteService.save(site);
-        return getAllGoodResponse();
     }
 
     private Site getSiteForRequestedPageInConfig(String url) {
         List<Site> siteList = sites.getSites();
         return siteList.stream()
-                .filter(site -> isPagePartOfSite(site.getUrl(), url))
+                .filter(site -> FormatUrlAction.isPagePartOfSite(site.getUrl(), url))
                 .findAny()
                 .orElse(null);
     }
@@ -204,12 +110,12 @@ public class IndexingServiceImpl implements IndexingService {
     @Override
     public IndexingResponse stopIndexing() {
         if (!isIndexingInProcess) {
-            return getIndexingNotStartedResponse();
+            return GenerateIndexingResponseAction.getIndexingNotStartedResponse();
         }
         executorThreadPool.shutdownNow();
-        setIndexingFlags(true, false);
+        setIndexingStoppedStatus();
         ParseAction.stopParsing();
-        return getIndexingStoppedByUserResponse();
+        return GenerateIndexingResponseAction.getIndexingStoppedByUserResponse();
     }
 
     @Override
@@ -217,37 +123,30 @@ public class IndexingServiceImpl implements IndexingService {
         log.info("Indexing page initiated by user, url - {}", url);
         Site siteInConfig = getSiteForRequestedPageInConfig(url);
         if (siteInConfig == null) {
-            return getPageNotListedInConfigResponse(url);
+            return GenerateIndexingResponseAction.getPageNotListedInConfigResponse(url);
         }
-        indexingAddedPage(url, siteInConfig);
-        return getAllGoodResponse();
+        setIndexingInProcessStatus();
+        ParseAction.isReadyForLimitedParsing();
+        Thread indexingTask = new Thread(() ->
+                indexingThreadAction.indexingAddedPage(url, siteInConfig), "page-indexing-thread");
+        indexingTask.start();
+        return GenerateIndexingResponseAction.getAllGoodResponse();
     }
 
-    @Transactional
-    public void indexingAddedPage(String url, Site siteInConfig) {
-        log.info("Indexing page is started, url - {}", url);
-        SiteEntity site = siteService.getByUrl(siteInConfig.getUrl());
-        if (site == null) {
-            site = siteService.createSiteByNameAndUrl(siteInConfig.getName(), siteInConfig.getUrl());
-            siteService.save(site);
-        }
-        PageEntity page = pageService.getByAbsPathAndSite(url, site);
-        if (page != null) {
-            prepareDatabaseBeforePartialIndexingStart(pageService, lemmaService, indexService, page);
-        }
-        parseAddedPage(url, site);
-        getResponseAccordingToSiteStatus(site);
-        log.info("Indexing page is finished, url - {}", url);
+    private void setIndexingInProcessStatus() {
+        setIndexingFlags(false, true);
     }
 
-    private void parseAddedPage(String url, SiteEntity site) {
-        ParseAction parser = new ParseAction(url, site, jsoupConfig, siteService, pageService, lemmaService, indexService);
-        ParseAction.readyForLimitedParsing();
-        parser.invoke();
+    private void setIndexingStoppedStatus() {
+        setIndexingFlags(true, true);
+    }
+
+    private void setIndexingCompletedStatus() {
+        setIndexingFlags(false, false);
     }
 
     private void setIndexingFlags(boolean isCancelledStopIndexing, boolean isIndexingInProcess) {
-        setCancelledStopIndexing(isCancelledStopIndexing);
+        IndexingThreadAction.setCancelledStopIndexing(isCancelledStopIndexing);
         setIndexingInProcess(isIndexingInProcess);
     }
 

--- a/src/main/java/searchengine/services/api/impl/StatisticsServiceImpl.java
+++ b/src/main/java/searchengine/services/api/impl/StatisticsServiceImpl.java
@@ -3,67 +3,77 @@ package searchengine.services.api.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
-import searchengine.config.Site;
-import searchengine.config.SitesList;
 import searchengine.dto.statistics.DetailedStatisticsItem;
 import searchengine.dto.statistics.StatisticsData;
 import searchengine.dto.statistics.StatisticsResponse;
 import searchengine.dto.statistics.TotalStatistics;
+import searchengine.model.SiteEntity;
+import searchengine.model.SiteIndexingStatus;
 import searchengine.services.api.StatisticsService;
+import searchengine.services.entity.LemmaService;
+import searchengine.services.entity.PageService;
+import searchengine.services.entity.SiteService;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 @Log4j2
 @Service
 @RequiredArgsConstructor
 public class StatisticsServiceImpl implements StatisticsService {
 
-    private final Random random = new Random();
-    private final SitesList sites;
+    private final SiteService siteService;
+    private final PageService pageService;
+    private final LemmaService lemmaService;
 
     @Override
     public StatisticsResponse getStatistics() {
         log.info("Statistics request is initiated");
-        String[] statuses = { "INDEXED", "FAILED", "INDEXING" };
-        String[] errors = {
-                "Ошибка индексации: главная страница сайта не доступна",
-                "Ошибка индексации: сайт не доступен",
-                ""
-        };
-
-        TotalStatistics total = new TotalStatistics();
-        total.setSites(sites.getSites().size());
-        total.setIndexing(true);
-
-        List<DetailedStatisticsItem> detailed = new ArrayList<>();
-        List<Site> sitesList = sites.getSites();
-        for(int i = 0; i < sitesList.size(); i++) {
-            Site site = sitesList.get(i);
-            DetailedStatisticsItem item = new DetailedStatisticsItem();
-            item.setName(site.getName());
-            item.setUrl(site.getUrl());
-            int pages = random.nextInt(1_000);
-            int lemmas = pages * random.nextInt(1_000);
-            item.setPages(pages);
-            item.setLemmas(lemmas);
-            item.setStatus(statuses[i % 3]);
-            item.setError(errors[i % 3]);
-            item.setStatusTime(System.currentTimeMillis() -
-                    (random.nextInt(10_000)));
-            total.setPages(total.getPages() + pages);
-            total.setLemmas(total.getLemmas() + lemmas);
-            detailed.add(item);
-        }
-
         StatisticsResponse response = new StatisticsResponse();
-        StatisticsData data = new StatisticsData();
-        data.setTotal(total);
-        data.setDetailed(detailed);
-        response.setStatistics(data);
-        response.setResult(true);
+        try {
+            response.setStatistics(getStatisticsData());
+            response.setResult(true);
+        } catch (Exception ex) {
+            response.setResult(false);
+            log.error("Error while getting statistics");
+        }
         log.info("Statistics request is completed");
         return response;
     }
+
+    private StatisticsData getStatisticsData() {
+        StatisticsData statisticsData = new StatisticsData();
+        List<SiteEntity> sites = siteService.getAll();
+        statisticsData.setTotal(getStatisticsTotalInfo(sites));
+        statisticsData.setDetailed(getStatisticsDetailedInfo(sites));
+        return statisticsData;
+    }
+
+    private TotalStatistics getStatisticsTotalInfo(List<SiteEntity> sites) {
+        TotalStatistics totalInfo = new TotalStatistics();
+        totalInfo.setSites(sites.size());
+        totalInfo.setPages(pageService.countAll().intValue());
+        totalInfo.setLemmas(lemmaService.countAll().intValue());
+        totalInfo.setIndexing(sites.stream().anyMatch(site -> site.getStatus().equals(SiteIndexingStatus.INDEXING)));
+        return totalInfo;
+    }
+
+    private List<DetailedStatisticsItem> getStatisticsDetailedInfo(List<SiteEntity> sites) {
+        List<DetailedStatisticsItem> detailedInfoList = new ArrayList<>();
+        for (SiteEntity site : sites) {
+            DetailedStatisticsItem detailedInfo = DetailedStatisticsItem.builder()
+                    .url(site.getUrl())
+                    .name(site.getName())
+                    .status(site.getStatus().name())
+                    .statusTime(site.getStatusTime().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
+                    .error(site.getLastError())
+                    .pages(pageService.countBySite(site))
+                    .lemmas(lemmaService.countBySite(site))
+                    .build();
+            detailedInfoList.add(detailedInfo);
+        }
+        return detailedInfoList;
+    }
+
 }

--- a/src/main/java/searchengine/services/entity/IndexService.java
+++ b/src/main/java/searchengine/services/entity/IndexService.java
@@ -10,6 +10,10 @@ import java.util.List;
 public interface IndexService {
     List<IndexEntity> getByPage(PageEntity page);
 
+    List<IndexEntity> getByLemma(LemmaEntity lemma);
+
+    IndexEntity getByLemmaAndPage(LemmaEntity lemma, PageEntity page);
+
     IndexEntity save(IndexEntity index);
 
     List<IndexEntity> saveAll(Collection<IndexEntity> indexes);

--- a/src/main/java/searchengine/services/entity/IndexService.java
+++ b/src/main/java/searchengine/services/entity/IndexService.java
@@ -1,0 +1,20 @@
+package searchengine.services.entity;
+
+import searchengine.model.IndexEntity;
+import searchengine.model.LemmaEntity;
+import searchengine.model.PageEntity;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface IndexService {
+    List<IndexEntity> getByPage(PageEntity page);
+
+    IndexEntity save(IndexEntity index);
+
+    List<IndexEntity> saveAll(Collection<IndexEntity> indexes);
+
+    void deleteAll(Iterable<IndexEntity> indexes);
+
+    void deleteAll();
+}

--- a/src/main/java/searchengine/services/entity/IndexService.java
+++ b/src/main/java/searchengine/services/entity/IndexService.java
@@ -17,4 +17,6 @@ public interface IndexService {
     void deleteAll(Iterable<IndexEntity> indexes);
 
     void deleteAll();
+
+    IndexEntity createIndexForPage(LemmaEntity lemmaEntity, Float rank, PageEntity page);
 }

--- a/src/main/java/searchengine/services/entity/LemmaService.java
+++ b/src/main/java/searchengine/services/entity/LemmaService.java
@@ -16,4 +16,7 @@ public interface LemmaService {
 
     void deleteAll();
 
+    LemmaEntity correctLemmaFrequencyBySite(String lemma, SiteEntity site);
+
+    void decreaseLemmaFrequencyInDatabase(LemmaEntity lemmaEntity);
 }

--- a/src/main/java/searchengine/services/entity/LemmaService.java
+++ b/src/main/java/searchengine/services/entity/LemmaService.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 public interface LemmaService {
 
+    Integer countBySite(SiteEntity siteEntity);
+
+    Long countAll();
+
     LemmaEntity save(LemmaEntity lemma);
 
     List<LemmaEntity> saveAll(Collection<LemmaEntity> lemmas);

--- a/src/main/java/searchengine/services/entity/LemmaService.java
+++ b/src/main/java/searchengine/services/entity/LemmaService.java
@@ -12,6 +12,8 @@ public interface LemmaService {
 
     Long countAll();
 
+    LemmaEntity getBySiteAndLemma(SiteEntity site, String lemma);
+
     LemmaEntity save(LemmaEntity lemma);
 
     List<LemmaEntity> saveAll(Collection<LemmaEntity> lemmas);

--- a/src/main/java/searchengine/services/entity/LemmaService.java
+++ b/src/main/java/searchengine/services/entity/LemmaService.java
@@ -1,0 +1,19 @@
+package searchengine.services.entity;
+
+import searchengine.model.LemmaEntity;
+import searchengine.model.SiteEntity;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface LemmaService {
+
+    LemmaEntity save(LemmaEntity lemma);
+
+    List<LemmaEntity> saveAll(Collection<LemmaEntity> lemmas);
+
+    void delete(LemmaEntity lemmaEntity);
+
+    void deleteAll();
+
+}

--- a/src/main/java/searchengine/services/entity/PageService.java
+++ b/src/main/java/searchengine/services/entity/PageService.java
@@ -13,6 +13,10 @@ public interface PageService {
 
     PageEntity getByAbsPathAndSite(String absPath, SiteEntity site);
 
+    Integer countBySite(SiteEntity siteEntity);
+
+    Long countAll();
+
     PageEntity save(PageEntity page);
 
     void delete(PageEntity page);

--- a/src/main/java/searchengine/services/entity/PageService.java
+++ b/src/main/java/searchengine/services/entity/PageService.java
@@ -4,7 +4,6 @@ import jakarta.annotation.Nullable;
 import searchengine.model.PageEntity;
 import searchengine.model.SiteEntity;
 
-import java.util.List;
 import java.util.Set;
 
 public interface PageService {

--- a/src/main/java/searchengine/services/entity/PageService.java
+++ b/src/main/java/searchengine/services/entity/PageService.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Nullable;
 import searchengine.model.PageEntity;
 import searchengine.model.SiteEntity;
 
+import java.util.List;
 import java.util.Set;
 
 public interface PageService {
@@ -13,6 +14,8 @@ public interface PageService {
     PageEntity getByAbsPathAndSite(String absPath, SiteEntity site);
 
     PageEntity save(PageEntity page);
+
+    void delete(PageEntity page);
 
     void deleteAll();
 

--- a/src/main/java/searchengine/services/entity/SiteService.java
+++ b/src/main/java/searchengine/services/entity/SiteService.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 public interface SiteService {
 
+    SiteEntity getByUrl(String url);
+
     List<SiteEntity> getAll();
 
     SiteEntity save(SiteEntity site);

--- a/src/main/java/searchengine/services/entity/impl/IndexServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/IndexServiceImpl.java
@@ -43,4 +43,13 @@ public class IndexServiceImpl implements IndexService {
     public void deleteAll() {
         indexRepository.deleteAllInBatch();
     }
+
+    @Override
+    public IndexEntity createIndexForPage(LemmaEntity lemmaEntity, Float rank, PageEntity page) {
+        IndexEntity indexEntity = new IndexEntity();
+        indexEntity.setPage(page);
+        indexEntity.setLemma(lemmaEntity);
+        indexEntity.setRank(rank);
+        return indexEntity;
+    }
 }

--- a/src/main/java/searchengine/services/entity/impl/IndexServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/IndexServiceImpl.java
@@ -25,6 +25,16 @@ public class IndexServiceImpl implements IndexService {
     }
 
     @Override
+    public List<IndexEntity> getByLemma(LemmaEntity lemma) {
+        return indexRepository.findByLemma(lemma);
+    }
+
+    @Override
+    public IndexEntity getByLemmaAndPage(LemmaEntity lemma, PageEntity page) {
+        return indexRepository.findByLemmaAndPage(lemma, page).orElse(null);
+    }
+
+    @Override
     public IndexEntity save(IndexEntity index) {
         return indexRepository.saveAndFlush(index);
     }

--- a/src/main/java/searchengine/services/entity/impl/IndexServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/IndexServiceImpl.java
@@ -1,0 +1,46 @@
+package searchengine.services.entity.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import searchengine.model.IndexEntity;
+import searchengine.model.LemmaEntity;
+import searchengine.model.PageEntity;
+import searchengine.repository.IndexRepository;
+import searchengine.services.entity.IndexService;
+
+import java.util.Collection;
+import java.util.List;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class IndexServiceImpl implements IndexService {
+
+    private final IndexRepository indexRepository;
+
+    @Override
+    public List<IndexEntity> getByPage(PageEntity page) {
+        return indexRepository.findByPage(page);
+    }
+
+    @Override
+    public IndexEntity save(IndexEntity index) {
+        return indexRepository.saveAndFlush(index);
+    }
+
+    @Override
+    public List<IndexEntity> saveAll(Collection<IndexEntity> indexes) {
+        return indexRepository.saveAllAndFlush(indexes);
+    }
+
+    @Override
+    public void deleteAll(Iterable<IndexEntity> indexes) {
+        indexRepository.deleteAllInBatch(indexes);
+    }
+
+    @Override
+    public void deleteAll() {
+        indexRepository.deleteAllInBatch();
+    }
+}

--- a/src/main/java/searchengine/services/entity/impl/LemmaServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/LemmaServiceImpl.java
@@ -20,6 +20,16 @@ public class LemmaServiceImpl implements LemmaService {
     private final LemmaRepository lemmaRepository;
 
     @Override
+    public Integer countBySite(SiteEntity siteEntity) {
+        return lemmaRepository.countBySite(siteEntity);
+    }
+
+    @Override
+    public Long countAll() {
+        return lemmaRepository.count();
+    }
+
+    @Override
     public LemmaEntity save(LemmaEntity lemma) {
         return lemmaRepository.saveAndFlush(lemma);
     }

--- a/src/main/java/searchengine/services/entity/impl/LemmaServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/LemmaServiceImpl.java
@@ -1,0 +1,40 @@
+package searchengine.services.entity.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import searchengine.model.LemmaEntity;
+import searchengine.model.SiteEntity;
+import searchengine.repository.LemmaRepository;
+import searchengine.services.entity.LemmaService;
+
+import java.util.*;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class LemmaServiceImpl implements LemmaService {
+
+    private final LemmaRepository lemmaRepository;
+
+    @Override
+    public LemmaEntity save(LemmaEntity lemma) {
+        return lemmaRepository.saveAndFlush(lemma);
+    }
+
+    @Override
+    public List<LemmaEntity> saveAll(Collection<LemmaEntity> lemmas) {
+        return lemmaRepository.saveAllAndFlush(lemmas);
+    }
+
+    @Override
+    public void delete(LemmaEntity lemmaEntity) {
+        lemmaRepository.delete(lemmaEntity);
+    }
+
+    @Override
+    public void deleteAll() {
+        lemmaRepository.deleteAllInBatch();
+    }
+
+}

--- a/src/main/java/searchengine/services/entity/impl/LemmaServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/LemmaServiceImpl.java
@@ -8,7 +8,9 @@ import searchengine.model.SiteEntity;
 import searchengine.repository.LemmaRepository;
 import searchengine.services.entity.LemmaService;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 @Log4j2
 @Service
@@ -35,6 +37,39 @@ public class LemmaServiceImpl implements LemmaService {
     @Override
     public void deleteAll() {
         lemmaRepository.deleteAllInBatch();
+    }
+
+    @Override
+    public LemmaEntity correctLemmaFrequencyBySite(String lemma, SiteEntity site) {
+        Optional<LemmaEntity> lemmaBySiteOptional = lemmaRepository.findBySiteAndLemma(site, lemma);
+        if (lemmaBySiteOptional.isPresent()) {
+            LemmaEntity lemmaEntity = lemmaBySiteOptional.get();
+            lemmaEntity.setFrequency(lemmaEntity.getFrequency() + 1);
+            return lemmaEntity;
+        }
+        return createLemmaEntity(lemma, site);
+    }
+
+    private LemmaEntity createLemmaEntity(String lemma, SiteEntity site) {
+        LemmaEntity lemmaEntity = new LemmaEntity();
+        lemmaEntity.setLemma(lemma);
+        lemmaEntity.setSite(site);
+        lemmaEntity.setFrequency(1);
+        return lemmaEntity;
+    }
+
+    @Override
+    public void decreaseLemmaFrequencyInDatabase(LemmaEntity lemmaEntity) {
+        Integer lemmaFrequency = lemmaEntity.getFrequency();
+        if (lemmaFrequency == 1) {
+            delete(lemmaEntity);
+            log.info("Lemma {} deleted", lemmaEntity.getLemma());
+        } else {
+            lemmaEntity.setFrequency(lemmaFrequency - 1);
+            save(lemmaEntity);
+            log.info("Lemma {} frequency was {} now {}",
+                    lemmaEntity.getLemma(), lemmaFrequency, lemmaEntity.getFrequency());
+        }
     }
 
 }

--- a/src/main/java/searchengine/services/entity/impl/LemmaServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/LemmaServiceImpl.java
@@ -30,6 +30,11 @@ public class LemmaServiceImpl implements LemmaService {
     }
 
     @Override
+    public LemmaEntity getBySiteAndLemma(SiteEntity site, String lemma) {
+        return lemmaRepository.findBySiteAndLemma(site, lemma).orElse(null);
+    }
+
+    @Override
     public LemmaEntity save(LemmaEntity lemma) {
         return lemmaRepository.saveAndFlush(lemma);
     }
@@ -54,13 +59,17 @@ public class LemmaServiceImpl implements LemmaService {
         Optional<LemmaEntity> lemmaBySiteOptional = lemmaRepository.findBySiteAndLemma(site, lemma);
         if (lemmaBySiteOptional.isPresent()) {
             LemmaEntity lemmaEntity = lemmaBySiteOptional.get();
-            lemmaEntity.setFrequency(lemmaEntity.getFrequency() + 1);
+            Integer oldFrequency = lemmaEntity.getFrequency();
+            lemmaEntity.setFrequency(oldFrequency + 1);
+            log.debug("Lemma '{}' is present in DB, frequency was {} now {}",
+                    lemma, oldFrequency, lemmaEntity.getFrequency());
             return lemmaEntity;
         }
         return createLemmaEntity(lemma, site);
     }
 
     private LemmaEntity createLemmaEntity(String lemma, SiteEntity site) {
+        log.debug("Creating new lemma '{}' for site {}", lemma, site.getUrl());
         LemmaEntity lemmaEntity = new LemmaEntity();
         lemmaEntity.setLemma(lemma);
         lemmaEntity.setSite(site);

--- a/src/main/java/searchengine/services/entity/impl/PageServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/PageServiceImpl.java
@@ -45,6 +45,16 @@ public class PageServiceImpl implements PageService {
     }
 
     @Override
+    public Integer countBySite(SiteEntity siteEntity) {
+        return pageRepository.countBySite(siteEntity);
+    }
+
+    @Override
+    public Long countAll() {
+        return pageRepository.count();
+    }
+
+    @Override
     public PageEntity save(PageEntity page) {
         if (!isHomePageRelativePath(page.getRelativePath())) {
             String relativePathWithoutEscapeEnd = removeEscapeEnd(page.getRelativePath());

--- a/src/main/java/searchengine/services/entity/impl/PageServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/PageServiceImpl.java
@@ -54,6 +54,11 @@ public class PageServiceImpl implements PageService {
     }
 
     @Override
+    public void delete(PageEntity page) {
+        pageRepository.delete(page);
+    }
+
+    @Override
     public void deleteAll() {
         pageRepository.deleteAllInBatch();
     }

--- a/src/main/java/searchengine/services/entity/impl/SiteServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/SiteServiceImpl.java
@@ -12,8 +12,6 @@ import searchengine.services.entity.SiteService;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static searchengine.model.SiteIndexingStatus.INDEXING;
-
 @Log4j2
 @Service
 @RequiredArgsConstructor
@@ -46,7 +44,7 @@ public class SiteServiceImpl implements SiteService {
         SiteEntity site = new SiteEntity();
         site.setName(name);
         site.setUrl(url);
-        site.setStatus(INDEXING);
+        site.setStatus(SiteIndexingStatus.INDEXING);
         site.setStatusTime(LocalDateTime.now());
         site.setLastError("");
         return site;

--- a/src/main/java/searchengine/services/entity/impl/SiteServiceImpl.java
+++ b/src/main/java/searchengine/services/entity/impl/SiteServiceImpl.java
@@ -22,6 +22,11 @@ public class SiteServiceImpl implements SiteService {
     private final SiteRepository siteRepository;
 
     @Override
+    public SiteEntity getByUrl(String url) {
+        return siteRepository.findByUrl(url).orElse(null);
+    }
+
+    @Override
     public List<SiteEntity> getAll() {
         return siteRepository.findAll();
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,7 +27,7 @@ indexing-settings:
       name: ЦГМБ имени М.А.Светлова
 
 jsoup-setting:
-  userAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 YaBrowser/21.9.0.1044 Yowser/2.5 Safari/537.36
+  userAgent: KapibaraSearchBot
   referrer: http://www.google.com
   timeout: 120_000
   pauseBeforeParseMultiplier: 15_000


### PR DESCRIPTION
Добавлены зависимости lucene для лемматизации.

Добавлены классы для сущностей БД lemma и search_index.

Добавлены JPA репозитории и слой сервисов для сущностей lemma и search_index.

Добавлен функционал для получения кода веб-страницы, его очистка от HTML-тэгов и преобразования в набор лемм и индексов с последующей записью этой информации в БД. Он встроен в механизм обхода сайтов таким образом, что каждая полученная страница сразу проходит индексацию и сохраняется в БД вместе с информацией о леммах и индексах.

Добавлен функционал для индексации и переиндексации одной веб-страницы с предварительным удалением из БД всей информации о ней.

Вспомогательный функционал вынесен в отдельные классы-хэлперы:
- обработка ошибок - в HandleExceptionsAction
- подготовка БД перед началом индексации - в PrepareDatabaseBeforeIndexingAction
- сбор лемм из текста - в CollectLemmasAction
- получение набора лемм и индексов, а также сопутствующей им информации - в ComputeIndexingInfoAction

Добавлен вспомогательный DTO PageIndexingData для представления набора лемм и индексов для отдельной страницы.

Добавлен ответ IndexingResponse в случае попытки индексации страницы с сайта, отсутствующего в конфигурационном файле.

Этап: 3